### PR TITLE
Reinstated the kernel module needed for the ethernet interface on RPi3B+

### DIFF
--- a/dynamic-layers/raspberrypi-layer/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/dynamic-layers/raspberrypi-layer/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -377,7 +377,7 @@ do_configure_append_sota() {
     kernel_configure_variable USB_PEGASUS n
     kernel_configure_variable USB_RTL8150 n
     kernel_configure_variable USB_RTL8152 n
-    kernel_configure_variable USB_LAN78XX n
+    kernel_configure_variable USB_LAN78XX y
     kernel_configure_variable USB_NET_AX8817X n
     kernel_configure_variable USB_NET_AX88179_178A n
     kernel_configure_variable USB_NET_CDCETHER n


### PR DESCRIPTION
Relates to [this](https://github.com/FullMetalUpdate/meta-fullmetalupdate-extra/issues/6) issue.

What the title says :-)

I think more changes are needed though as this still doesn't result in a working RPI3B+ target. For starters the device fails to get an IP address via DHCP.