### PR TITLE
Add imx8mqevk on warrior release

### DIFF
--- a/conf/imx8mqevk/layer.conf
+++ b/conf/imx8mqevk/layer.conf
@@ -18,4 +18,7 @@ BBFILES_DYNAMIC += " \
     \
     freescale-layer:${LAYERDIR}/dynamic-layers/freescale-layer/*/*/*.bb \
     freescale-layer:${LAYERDIR}/dynamic-layers/freescale-layer/*/*/*.bbappend \
+    \
+    core:${LAYERDIR}/dynamic-layers/poky-layer/*/*/*.bb \
+    core:${LAYERDIR}/dynamic-layers/poky-layer/*/*/*.bbappend \
 "

--- a/dynamic-layers/poky-layer/recipes-core/sysvinit/sysvinit_%.bbappend
+++ b/dynamic-layers/poky-layer/recipes-core/sysvinit/sysvinit_%.bbappend
@@ -1,0 +1,4 @@
+
+do_install_append () {
+	rm -f ${D}${sbindir}/telinit
+}

--- a/recipes-containers/container-tensorflow-lite-label-image/container-tensorflow-lite-label-image_imx8mqevk.inc
+++ b/recipes-containers/container-tensorflow-lite-label-image/container-tensorflow-lite-label-image_imx8mqevk.inc
@@ -1,0 +1,3 @@
+# Adding bash to fix rpm issue
+IMAGE_INSTALL_append = " bash"
+

--- a/recipes-containers/container-tensorflow-lite-label-image/imx8mqevk/tensorflow-lite-label-image-config.json
+++ b/recipes-containers/container-tensorflow-lite-label-image/imx8mqevk/tensorflow-lite-label-image-config.json
@@ -1,0 +1,175 @@
+{
+	"ociVersion": "1.0.0",
+	"process": {
+		"terminal": false,
+		"user": {
+			"uid": 1000,
+			"gid": 1000
+		},
+		"args": [
+			"./entry.sh"
+		],
+		"env": [
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm"
+		],
+		"cwd": "/",
+		"capabilities": {
+			"bounding": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			],
+			"effective": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			],
+			"inheritable": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			],
+			"permitted": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			],
+			"ambient": [
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+				"CAP_NET_BIND_SERVICE"
+			]
+		},
+		"rlimits": [
+			{
+				"type": "RLIMIT_NOFILE",
+				"hard": 1024,
+				"soft": 1024
+			}
+		],
+		"noNewPrivileges": true
+	},
+	"root": {
+		"path": "rootfs",
+		"readonly": true
+	},
+	"hostname": "witekio-demo",
+	"mounts": [
+		{
+			"destination": "/proc",
+			"type": "proc",
+			"source": "proc"
+		},
+		{
+			"destination": "/dev",
+			"type": "tmpfs",
+			"source": "tmpfs",
+			"options": [
+				"nosuid",
+				"strictatime",
+				"mode=755",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/pts",
+			"type": "devpts",
+			"source": "devpts",
+			"options": [
+				"nosuid",
+				"noexec",
+				"newinstance",
+				"ptmxmode=0666",
+				"mode=0620",
+				"gid=5"
+			]
+		},
+		{
+			"destination": "/dev/shm",
+			"type": "tmpfs",
+			"source": "shm",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"mode=1777",
+				"size=65536k"
+			]
+		},
+		{
+			"destination": "/dev/mqueue",
+			"type": "mqueue",
+			"source": "mqueue",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev"
+			]
+		},
+		{
+			"destination": "/sys",
+			"type": "sysfs",
+			"source": "sysfs",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"ro"
+			]
+		},
+		{
+			"destination": "/sys/fs/cgroup",
+			"type": "cgroup",
+			"source": "cgroup",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"relatime",
+				"ro"
+			]
+		}
+	],
+	"linux": {
+		"resources": {
+			"devices": [
+				{
+					"allow": false,
+					"access": "rwm"
+				}
+			]
+		},
+		"namespaces": [
+			{
+				"type": "pid"
+			},
+			{
+				"type": "ipc"
+			},
+			{
+				"type": "uts"
+			},
+			{
+				"type": "mount"
+			}
+		],
+		"maskedPaths": [
+			"/proc/kcore",
+			"/proc/latency_stats",
+			"/proc/timer_list",
+			"/proc/timer_stats",
+			"/proc/sched_debug",
+			"/sys/firmware",
+			"/proc/scsi"
+		],
+		"readonlyPaths": [
+			"/proc/asound",
+			"/proc/bus",
+			"/proc/fs",
+			"/proc/irq",
+			"/proc/sys",
+			"/proc/sysrq-trigger"
+		]
+	}
+}

--- a/recipes-core/images/fullmetalupdate-containers-package_imx8mqevk.inc
+++ b/recipes-core/images/fullmetalupdate-containers-package_imx8mqevk.inc
@@ -2,4 +2,4 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 PREINSTALLED_CONTAINERS_LIST_append = "container-hello-world"
 
-IMAGE_ROOTFS_EXTRA_SPACE = "314572"
+IMAGE_ROOTFS_EXTRA_SPACE = "629504"

--- a/recipes-core/images/fullmetalupdate-containers-package_imx8mqevk.inc
+++ b/recipes-core/images/fullmetalupdate-containers-package_imx8mqevk.inc
@@ -1,5 +1,5 @@
 # Copyright (C) 2019 Witekio
 # Released under the MIT license (see COPYING.MIT for the terms)
-PREINSTALLED_CONTAINERS_LIST_append = "container-hello-world container-qt-evcs"
+PREINSTALLED_CONTAINERS_LIST_append = "container-hello-world"
 
 IMAGE_ROOTFS_EXTRA_SPACE = "314572"


### PR DESCRIPTION
There were two issues : 
 - At `do_rootfs`, `telinit` was installed by `systemd` and `sysvinit`. Fixed by removing `telinit` from `sysvinit`'s `sbindir` directory. Same thing as dynamic-layers/stm-st-stm32mp-layer/recipes-core/sysvinit/sysvinit_%.bbappend (b0152f5) 
 - Removed evcs from the list of pre-installed containers. This also caused Ostree to fail when trying to fetch it from the hawkbit remote (4c85d5e) 